### PR TITLE
Visitor can see products sorted in different categories

### DIFF
--- a/cypress/fixtures/menuItems.json
+++ b/cypress/fixtures/menuItems.json
@@ -47,6 +47,22 @@
       "description": "Smelly Belly",
       "price": 100,
       "image": "https://picsum.photos/200"
-    }
+    },
+    {
+    "id": 7,
+      "category": "side",
+      "name": "Bread",
+      "description": "Bread",
+      "price": 15,
+      "image": "https://picsum.photos/200"
+    },
+    {
+      "id": 7,
+        "category": "drink",
+        "name": "Mouse Wine",
+        "description": "Squeek!",
+        "price": 35,
+        "image": "https://picsum.photos/200"
+      }
   ]
 }

--- a/cypress/fixtures/menuItems.json
+++ b/cypress/fixtures/menuItems.json
@@ -18,7 +18,7 @@
     },
     {
       "id": 3,
-      "category": "main menu",
+      "category": "main_courses",
       "name": "Kangaroo Steak",
       "description": "Bouncy bouncy",
       "price": 500,
@@ -26,7 +26,7 @@
     },
     {
       "id": 4,
-      "category": "main menu",
+      "category": "main_courses",
       "name": "Hedgehog Ragu´",
       "description": "Tons of spikes",
       "price": 500,
@@ -34,31 +34,31 @@
     },
     {
       "id": 5,
-      "category": "dessert",
+      "category": "desserts",
       "name": "Durian",
-      "description": "Smelly Smelly",
+      "description": "Smelly smelly",
       "price": 100,
       "image": "https://picsum.photos/200"
     },
     {
       "id": 6,
-      "category": "dessert",
+      "category": "desserts",
       "name": "Feet Shavings",
-      "description": "Smelly Belly",
+      "description": "Smelly selly",
       "price": 100,
       "image": "https://picsum.photos/200"
     },
     {
     "id": 7,
-      "category": "side",
+      "category": "sides",
       "name": "Bread",
       "description": "Bread",
       "price": 15,
       "image": "https://picsum.photos/200"
     },
     {
-      "id": 7,
-        "category": "drink",
+      "id": 8,
+        "category": "drinks",
         "name": "Mouse Wine",
         "description": "Squeek!",
         "price": 35,

--- a/cypress/integration/userCanNavigateTheWebsite.feature.js
+++ b/cypress/integration/userCanNavigateTheWebsite.feature.js
@@ -1,8 +1,10 @@
 describe("User can browser through the app", () => {
   beforeEach(() => {
+    cy.intercept("**api/products", {
+      fixture: "menuItems.json",
+    });
     cy.visit("/");
   });
-
   it("is expected to display the name of the resturant", () => {
     cy.get("[data-cy=resturant-name]").should(
       "contain",
@@ -31,12 +33,12 @@ describe("User can browser through the app", () => {
   it("is expected to display a footer", () => {
     cy.get("[data-cy=footer]").should("contain", "Funny quip goes here");
   });
-  it('is expected to display a menu page', () => {
-    cy.get("[data-cy=menu]").click()
-    cy.get("[data-cy=menu-section]").should("be.visible")
+  it("is expected to display a menu page", () => {
+    cy.get("[data-cy=menu]").click();
+    cy.get("[data-cy=menu-section]").should("be.visible");
   });
-  it('is expected to display a about page', () => {
-    cy.get("[data-cy=about]").click()
-    cy.get("[data-cy=about-section]").should("be.visible")
+  it("is expected to display a about page", () => {
+    cy.get("[data-cy=about]").click();
+    cy.get("[data-cy=about-section]").should("be.visible");
   });
 });

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -6,28 +6,18 @@ describe("User can see menu", () => {
     cy.visit("/");
     cy.get("[data-cy=menu]").click();
   });
-
-  // it("is expected to show the first item in the Starters menu", () => {
-  //   cy.get("[data-cy=item-1]").within(() => {
-  //     cy.get("[data-cy=name]").should("contain", "Insect");
-  //     cy.get("[data-cy=description]").should("contain", "Creepy Crawlies");
-  //     cy.get("[data-cy=price]").should("contain", "250 kr");
-  //     cy.get("[data-cy=image]").should("be.visible");
-  //     cy.get("[data-cy=add-to-basket]").should("be.visible");
-  //   });
-  // });
-
   it("is expected to show six items in the menu", () => {
     cy.get("[data-cy=menu-section]").children().should("have.length", 6);
   });
 
   describe("User can see menu-items by category", () => {
     it("is expected to display starter menu-items", () => {
-      cy.get("[data-cy=starter-tab]").click();
-      cy.get("[data-cy=starter-header]").should("contain", "Starters");
+      cy.get("[data-cy=starter-tab]").should("contain", "Starters");
     });
     it("is expected to display the content of starter-menu-item", () => {
+      cy.get("[data-cy=starter-tab]").click();
       cy.get("[data-cy=starter-menu-item-1]").within(() => {
+        cy.get("[data-cy=starter-header]").should("contain", "Starters");
         cy.get("[data-cy=name]").should("contain", "Insect");
         cy.get("[data-cy=description]").should("contain", "Creepy Crawlies");
         cy.get("[data-cy=price]").should("contain", "250 kr");
@@ -35,7 +25,6 @@ describe("User can see menu", () => {
         cy.get("[data-cy=starter-basket-1]").should("be.visible");
       });
     });
-
     it("is expected to display main-menu items", () => {
       cy.get("[data-cy=main-menu-tab]").click();
       cy.get("[data-cy=main-menu-header]").should("contain", "Main Menu");

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -20,6 +20,7 @@ describe("User can see menu", () => {
   it("is expected to show six items in the menu", () => {
     cy.get("[data-cy=menu-section]").children().should("have.length", 6);
   });
+
   describe("User can see menu-items by category", () => {
     it("is expected to display starter menu-items", () => {
       cy.get("[data-cy=starter-tab]").click();
@@ -34,18 +35,47 @@ describe("User can see menu", () => {
         cy.get("[data-cy=starter-basket-1]").should("be.visible");
       });
     });
-    it('is expected to display main-menu items', () => {
-      cy.get("[data-cy=main-menu-tab]").click()
-      cy.get("[data-cy=main-menu-header]").should('contain', 'Main Menu')
+
+    it("is expected to display main-menu items", () => {
+      cy.get("[data-cy=main-menu-tab]").click();
+      cy.get("[data-cy=main-menu-header]").should("contain", "Main Menu");
     });
-    it('is expected to display the content of main-menu items', () => {
+    it("is expected to display the content of main-menu items", () => {
       cy.get("[data-cy=main-menu-item-1]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
         cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
         cy.get("[data-cy=price]").should("contain", "500 kr");
         cy.get("[data-cy=image]").should("be.visible");
         cy.get("[data-cy=main-basket-1]").should("be.visible");
-      })
+      });
+    });
+
+    it("is expected to display desert items", () => {
+      cy.get("[data-cy=dessert-tab]").click();
+      cy.get("[data-cy=dessert-header]").should("contain", "Dessert");
+    });
+    it("is expected to display the content of the desset items", () => {
+      cy.get("[data-cy=dessert-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Durian");
+        cy.get("[data-cy=description]").should("contain", "Smelly smelly");
+        cy.get("[data-cy=price]").should("contain", "100 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      });
+    });
+
+    it("is expected to display sides items", () => {
+      cy.get("[data-cy=sides-tab]").click();
+      cy.get("[data-cy=sides-header]").should("contain", "Sides");
+    });
+    it("is expected to display the content of the sides items", () => {
+      cy.get("[data-cy=sides-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Bread");
+        cy.get("[data-cy=description]").should("contain", "Bread");
+        cy.get("[data-cy=price]").should("contain", "15 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      });
     });
   });
 });

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -6,77 +6,65 @@ describe("User can see menu", () => {
     cy.visit("/");
     cy.get("[data-cy=menu]").click();
   });
-   
+
   describe("User can see menu-items by category", () => {
-    it("is expected to display starter menu-items", () => {
-      cy.get("[data-cy=starter-tab]").should("contain", "Starters");
-    });
-    it("is expected to display the content of starter-menu-item", () => {
+    it("is expected to display the content of starter-menu", () => {
       cy.get("[data-cy=starter-tab]").click();
       cy.get("[data-cy=menu-section]").children().should("have.length", 2);
-      cy.get("[data-cy=starter-menu-item-1]").within(() => {
-      cy.get("[data-cy=starter-header]").should("contain", "Starters");
+      cy.get("[data-cy=item-1]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Insect");
         cy.get("[data-cy=description]").should("contain", "Creepy Crawlies");
         cy.get("[data-cy=price]").should("contain", "250 kr");
         cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=starter-basket-1]").should("be.visible");
+        cy.get("[data-cy=add-to-basket-1]").should("be.visible");
       });
     });
 
-    it("is expected to display main_courses items", () => {
-      cy.get("[data-cy=main-menu-tab]").should("contain", "Main Courses");
-    });
-    it("is expected to display the content of main-menu items", () => {
-      cy.get("[data-cy=main-menu-tab]").click();
-      cy.get("[data-cy=main-menu-item-1]").within(() => {
+    it("is expected to display the content of main courses", () => {
+      cy.get("[data-cy=main-courses-tab]").click();
+      cy.get("[data-cy=menu-section]").children().should("have.length", 2);
+      cy.get("[data-cy=item-3]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
         cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
         cy.get("[data-cy=price]").should("contain", "500 kr");
         cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
+        cy.get("[data-cy=add-to-basket-3]").should("be.visible");
       });
     });
 
-    it("is expected to display desert items", () => {
-      cy.get("[data-cy=dessert-tab]").should("contain", "Dessert");
-    });
-    it("is expected to display the content of the desset items", () => {
-      cy.get("[data-cy=dessert-tab]").click();
-      cy.get("[data-cy=dessert-item-1]").within(() => {
+    it("is expected to display the content of the desset", () => {
+      cy.get("[data-cy=desserts-tab]").click();
+      cy.get("[data-cy=menu-section]").children().should("have.length", 2);
+      cy.get("[data-cy=item-5]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Durian");
         cy.get("[data-cy=description]").should("contain", "Smelly smelly");
         cy.get("[data-cy=price]").should("contain", "100 kr");
         cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
+        cy.get("[data-cy=add-to-basket-5]").should("be.visible");
       });
     });
 
-    it("is expected to display sides items", () => {
-      cy.get("[data-cy=sides-tab]").should("contain", "Sides");
-    });
-    it("is expected to display the content of the sides items", () => {
+    it("is expected to display the content of the sides", () => {
       cy.get("[data-cy=sides-tab]").click();
-      cy.get("[data-cy=sides-item-1]").within(() => {
+      cy.get("[data-cy=menu-section]").children().should("have.length", 1);
+      cy.get("[data-cy=item-7]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Bread");
         cy.get("[data-cy=description]").should("contain", "Bread");
         cy.get("[data-cy=price]").should("contain", "15 kr");
         cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
+        cy.get("[data-cy=add-to-basket-7]").should("be.visible");
       });
     });
 
-    it("is expected to display drink items", () => {
-      cy.get("[data-cy=drinks-tab]").should("contain", "Drinks");
-    });
-    it("is expected to display the contenet of the drink items", () => {
-      cy.get("[data-cy=sides-tab]").click();
-      cy.get("[data-cy=sides-item-1]").within(() => {
+    it("is expected to display the contenet of the drinks", () => {
+      cy.get("[data-cy=drinks-tab]").click();
+      cy.get("[data-cy=menu-section]").children().should("have.length", 1);
+      cy.get("[data-cy=item-8]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Mouse Wine");
         cy.get("[data-cy=description]").should("contain", "Squeek!");
         cy.get("[data-cy=price]").should("contain", "35 kr");
         cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
+        cy.get("[data-cy=add-to-basket-8]").should("be.visible");
       });
     });
   });

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -7,17 +7,45 @@ describe("User can see menu", () => {
     cy.get("[data-cy=menu]").click();
   });
 
-  it("is expected to show the first item in the Starters menu", () => {
-    cy.get("[data-cy=item-1]").within(() => {
-      cy.get("[data-cy=name]").should("contain", "Insect");
-      cy.get("[data-cy=description]").should("contain", "Creepy Crawlies");
-      cy.get("[data-cy=price]").should("contain", "250 kr");
-      cy.get("[data-cy=image]").should("be.visible");
-      cy.get("[data-cy=add-to-basket]").should("be.visible");
-    });
-  });
+  // it("is expected to show the first item in the Starters menu", () => {
+  //   cy.get("[data-cy=item-1]").within(() => {
+  //     cy.get("[data-cy=name]").should("contain", "Insect");
+  //     cy.get("[data-cy=description]").should("contain", "Creepy Crawlies");
+  //     cy.get("[data-cy=price]").should("contain", "250 kr");
+  //     cy.get("[data-cy=image]").should("be.visible");
+  //     cy.get("[data-cy=add-to-basket]").should("be.visible");
+  //   });
+  // });
 
   it("is expected to show six items in the menu", () => {
     cy.get("[data-cy=menu-section]").children().should("have.length", 6);
+  });
+  describe("User can see menu-items by category", () => {
+    it("is expected to display starter menu-items", () => {
+      cy.get("[data-cy=starter-tab]").click();
+      cy.get("[data-cy=starter-header]").should("contain", "Starters");
+    });
+    it("is expected to display the content of starter-menu-item", () => {
+      cy.get("[data-cy=starter-menu-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Insect");
+        cy.get("[data-cy=description]").should("contain", "Creepy Crawlies");
+        cy.get("[data-cy=price]").should("contain", "250 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=starter-basket-1]").should("be.visible");
+      });
+    });
+    it('is expected to display main-menu items', () => {
+      cy.get("[data-cy=main-menu-tab]").click()
+      cy.get("[data-cy=main-menu-header]").should('contain', 'Main Menu')
+    });
+    it('is expected to display the content of main-menu items', () => {
+      cy.get("[data-cy=main-menu-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
+        cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
+        cy.get("[data-cy=price]").should("contain", "500 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      })
+    });
   });
 });

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -26,60 +26,60 @@ describe("User can see menu", () => {
       });
     });
 
-    it("is expected to display main-menu items", () => {
-      cy.get("[data-cy=main-menu-tab]").should("contain", "Main Menu");
-    });
-    it("is expected to display the content of main-menu items", () => {
-      cy.get("[data-cy=main-menu-tab]").click();
-      cy.get("[data-cy=main-menu-item-1]").within(() => {
-        cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
-        cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
-        cy.get("[data-cy=price]").should("contain", "500 kr");
-        cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
-      });
-    });
+    // it("is expected to display main-menu items", () => {
+    //   cy.get("[data-cy=main-menu-tab]").should("contain", "Main Menu");
+    // });
+    // it("is expected to display the content of main-menu items", () => {
+    //   cy.get("[data-cy=main-menu-tab]").click();
+    //   cy.get("[data-cy=main-menu-item-1]").within(() => {
+    //     cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
+    //     cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
+    //     cy.get("[data-cy=price]").should("contain", "500 kr");
+    //     cy.get("[data-cy=image]").should("be.visible");
+    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
+    //   });
+    // });
 
-    it("is expected to display desert items", () => {
-      cy.get("[data-cy=dessert-tab]").should("contain", "Dessert");
-    });
-    it("is expected to display the content of the desset items", () => {
-      cy.get("[data-cy=dessert-tab]").click();
-      cy.get("[data-cy=dessert-item-1]").within(() => {
-        cy.get("[data-cy=name]").should("contain", "Durian");
-        cy.get("[data-cy=description]").should("contain", "Smelly smelly");
-        cy.get("[data-cy=price]").should("contain", "100 kr");
-        cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
-      });
-    });
+    // it("is expected to display desert items", () => {
+    //   cy.get("[data-cy=dessert-tab]").should("contain", "Dessert");
+    // });
+    // it("is expected to display the content of the desset items", () => {
+    //   cy.get("[data-cy=dessert-tab]").click();
+    //   cy.get("[data-cy=dessert-item-1]").within(() => {
+    //     cy.get("[data-cy=name]").should("contain", "Durian");
+    //     cy.get("[data-cy=description]").should("contain", "Smelly smelly");
+    //     cy.get("[data-cy=price]").should("contain", "100 kr");
+    //     cy.get("[data-cy=image]").should("be.visible");
+    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
+    //   });
+    // });
 
-    it("is expected to display sides items", () => {
-      cy.get("[data-cy=sides-tab]").should("contain", "Sides");
-    });
-    it("is expected to display the content of the sides items", () => {
-      cy.get("[data-cy=sides-tab]").click();
-      cy.get("[data-cy=sides-item-1]").within(() => {
-        cy.get("[data-cy=name]").should("contain", "Bread");
-        cy.get("[data-cy=description]").should("contain", "Bread");
-        cy.get("[data-cy=price]").should("contain", "15 kr");
-        cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
-      });
-    });
+    // it("is expected to display sides items", () => {
+    //   cy.get("[data-cy=sides-tab]").should("contain", "Sides");
+    // });
+    // it("is expected to display the content of the sides items", () => {
+    //   cy.get("[data-cy=sides-tab]").click();
+    //   cy.get("[data-cy=sides-item-1]").within(() => {
+    //     cy.get("[data-cy=name]").should("contain", "Bread");
+    //     cy.get("[data-cy=description]").should("contain", "Bread");
+    //     cy.get("[data-cy=price]").should("contain", "15 kr");
+    //     cy.get("[data-cy=image]").should("be.visible");
+    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
+    //   });
+    // });
 
-    it("is expected to display drink items", () => {
-      cy.get("[data-cy=drinks-tab]").should("contain", "Drinks");
-    });
-    it("is expected to display the contenet of the drink items", () => {
-      cy.get("[data-cy=sides-tab]").click();
-      cy.get("[data-cy=sides-item-1]").within(() => {
-        cy.get("[data-cy=name]").should("contain", "Mouse Wine");
-        cy.get("[data-cy=description]").should("contain", "Squeek!");
-        cy.get("[data-cy=price]").should("contain", "35 kr");
-        cy.get("[data-cy=image]").should("be.visible");
-        cy.get("[data-cy=main-basket-1]").should("be.visible");
-      });
-    });
+    // it("is expected to display drink items", () => {
+    //   cy.get("[data-cy=drinks-tab]").should("contain", "Drinks");
+    // });
+    // it("is expected to display the contenet of the drink items", () => {
+    //   cy.get("[data-cy=sides-tab]").click();
+    //   cy.get("[data-cy=sides-item-1]").within(() => {
+    //     cy.get("[data-cy=name]").should("contain", "Mouse Wine");
+    //     cy.get("[data-cy=description]").should("contain", "Squeek!");
+    //     cy.get("[data-cy=price]").should("contain", "35 kr");
+    //     cy.get("[data-cy=image]").should("be.visible");
+    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
+    //   });
+    // });
   });
 });

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -6,8 +6,8 @@ describe("User can see menu", () => {
     cy.visit("/");
     cy.get("[data-cy=menu]").click();
   });
-  it("is expected to show six items in the menu", () => {
-    cy.get("[data-cy=menu-section]").children().should("have.length", 6);
+  it("is expected to show eight items in the menu", () => {
+    cy.get("[data-cy=menu-section]").children().should("have.length", 8);
   });
 
   describe("User can see menu-items by category", () => {
@@ -25,11 +25,12 @@ describe("User can see menu", () => {
         cy.get("[data-cy=starter-basket-1]").should("be.visible");
       });
     });
+
     it("is expected to display main-menu items", () => {
-      cy.get("[data-cy=main-menu-tab]").click();
-      cy.get("[data-cy=main-menu-header]").should("contain", "Main Menu");
+      cy.get("[data-cy=main-menu-tab]").should("contain", "Main Menu");
     });
     it("is expected to display the content of main-menu items", () => {
+      cy.get("[data-cy=main-menu-tab]").click();
       cy.get("[data-cy=main-menu-item-1]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
         cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
@@ -40,10 +41,10 @@ describe("User can see menu", () => {
     });
 
     it("is expected to display desert items", () => {
-      cy.get("[data-cy=dessert-tab]").click();
-      cy.get("[data-cy=dessert-header]").should("contain", "Dessert");
+      cy.get("[data-cy=dessert-tab]").should("contain", "Dessert");
     });
     it("is expected to display the content of the desset items", () => {
+      cy.get("[data-cy=dessert-tab]").click();
       cy.get("[data-cy=dessert-item-1]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Durian");
         cy.get("[data-cy=description]").should("contain", "Smelly smelly");
@@ -54,14 +55,28 @@ describe("User can see menu", () => {
     });
 
     it("is expected to display sides items", () => {
-      cy.get("[data-cy=sides-tab]").click();
-      cy.get("[data-cy=sides-header]").should("contain", "Sides");
+      cy.get("[data-cy=sides-tab]").should("contain", "Sides");
     });
     it("is expected to display the content of the sides items", () => {
+      cy.get("[data-cy=sides-tab]").click();
       cy.get("[data-cy=sides-item-1]").within(() => {
         cy.get("[data-cy=name]").should("contain", "Bread");
         cy.get("[data-cy=description]").should("contain", "Bread");
         cy.get("[data-cy=price]").should("contain", "15 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      });
+    });
+
+    it("is expected to display drink items", () => {
+      cy.get("[data-cy=drinks-tab]").should("contain", "Drinks");
+    });
+    it("is expected to display the contenet of the drink items", () => {
+      cy.get("[data-cy=sides-tab]").click();
+      cy.get("[data-cy=sides-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Mouse Wine");
+        cy.get("[data-cy=description]").should("contain", "Squeek!");
+        cy.get("[data-cy=price]").should("contain", "35 kr");
         cy.get("[data-cy=image]").should("be.visible");
         cy.get("[data-cy=main-basket-1]").should("be.visible");
       });

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -6,18 +6,16 @@ describe("User can see menu", () => {
     cy.visit("/");
     cy.get("[data-cy=menu]").click();
   });
-  it("is expected to show eight items in the menu", () => {
-    cy.get("[data-cy=menu-section]").children().should("have.length", 8);
-  });
-
+   
   describe("User can see menu-items by category", () => {
     it("is expected to display starter menu-items", () => {
       cy.get("[data-cy=starter-tab]").should("contain", "Starters");
     });
     it("is expected to display the content of starter-menu-item", () => {
       cy.get("[data-cy=starter-tab]").click();
+      cy.get("[data-cy=menu-section]").children().should("have.length", 2);
       cy.get("[data-cy=starter-menu-item-1]").within(() => {
-        cy.get("[data-cy=starter-header]").should("contain", "Starters");
+      cy.get("[data-cy=starter-header]").should("contain", "Starters");
         cy.get("[data-cy=name]").should("contain", "Insect");
         cy.get("[data-cy=description]").should("contain", "Creepy Crawlies");
         cy.get("[data-cy=price]").should("contain", "250 kr");
@@ -26,8 +24,8 @@ describe("User can see menu", () => {
       });
     });
 
-    it("is expected to display main-menu items", () => {
-      cy.get("[data-cy=main-menu-tab]").should("contain", "Main Menu");
+    it("is expected to display main_courses items", () => {
+      cy.get("[data-cy=main-menu-tab]").should("contain", "Main Courses");
     });
     it("is expected to display the content of main-menu items", () => {
       cy.get("[data-cy=main-menu-tab]").click();

--- a/cypress/integration/userCanSeeTheMenuList.feature.js
+++ b/cypress/integration/userCanSeeTheMenuList.feature.js
@@ -26,60 +26,60 @@ describe("User can see menu", () => {
       });
     });
 
-    // it("is expected to display main-menu items", () => {
-    //   cy.get("[data-cy=main-menu-tab]").should("contain", "Main Menu");
-    // });
-    // it("is expected to display the content of main-menu items", () => {
-    //   cy.get("[data-cy=main-menu-tab]").click();
-    //   cy.get("[data-cy=main-menu-item-1]").within(() => {
-    //     cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
-    //     cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
-    //     cy.get("[data-cy=price]").should("contain", "500 kr");
-    //     cy.get("[data-cy=image]").should("be.visible");
-    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
-    //   });
-    // });
+    it("is expected to display main-menu items", () => {
+      cy.get("[data-cy=main-menu-tab]").should("contain", "Main Menu");
+    });
+    it("is expected to display the content of main-menu items", () => {
+      cy.get("[data-cy=main-menu-tab]").click();
+      cy.get("[data-cy=main-menu-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Kangaroo Steak");
+        cy.get("[data-cy=description]").should("contain", "Bouncy bouncy");
+        cy.get("[data-cy=price]").should("contain", "500 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      });
+    });
 
-    // it("is expected to display desert items", () => {
-    //   cy.get("[data-cy=dessert-tab]").should("contain", "Dessert");
-    // });
-    // it("is expected to display the content of the desset items", () => {
-    //   cy.get("[data-cy=dessert-tab]").click();
-    //   cy.get("[data-cy=dessert-item-1]").within(() => {
-    //     cy.get("[data-cy=name]").should("contain", "Durian");
-    //     cy.get("[data-cy=description]").should("contain", "Smelly smelly");
-    //     cy.get("[data-cy=price]").should("contain", "100 kr");
-    //     cy.get("[data-cy=image]").should("be.visible");
-    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
-    //   });
-    // });
+    it("is expected to display desert items", () => {
+      cy.get("[data-cy=dessert-tab]").should("contain", "Dessert");
+    });
+    it("is expected to display the content of the desset items", () => {
+      cy.get("[data-cy=dessert-tab]").click();
+      cy.get("[data-cy=dessert-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Durian");
+        cy.get("[data-cy=description]").should("contain", "Smelly smelly");
+        cy.get("[data-cy=price]").should("contain", "100 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      });
+    });
 
-    // it("is expected to display sides items", () => {
-    //   cy.get("[data-cy=sides-tab]").should("contain", "Sides");
-    // });
-    // it("is expected to display the content of the sides items", () => {
-    //   cy.get("[data-cy=sides-tab]").click();
-    //   cy.get("[data-cy=sides-item-1]").within(() => {
-    //     cy.get("[data-cy=name]").should("contain", "Bread");
-    //     cy.get("[data-cy=description]").should("contain", "Bread");
-    //     cy.get("[data-cy=price]").should("contain", "15 kr");
-    //     cy.get("[data-cy=image]").should("be.visible");
-    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
-    //   });
-    // });
+    it("is expected to display sides items", () => {
+      cy.get("[data-cy=sides-tab]").should("contain", "Sides");
+    });
+    it("is expected to display the content of the sides items", () => {
+      cy.get("[data-cy=sides-tab]").click();
+      cy.get("[data-cy=sides-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Bread");
+        cy.get("[data-cy=description]").should("contain", "Bread");
+        cy.get("[data-cy=price]").should("contain", "15 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      });
+    });
 
-    // it("is expected to display drink items", () => {
-    //   cy.get("[data-cy=drinks-tab]").should("contain", "Drinks");
-    // });
-    // it("is expected to display the contenet of the drink items", () => {
-    //   cy.get("[data-cy=sides-tab]").click();
-    //   cy.get("[data-cy=sides-item-1]").within(() => {
-    //     cy.get("[data-cy=name]").should("contain", "Mouse Wine");
-    //     cy.get("[data-cy=description]").should("contain", "Squeek!");
-    //     cy.get("[data-cy=price]").should("contain", "35 kr");
-    //     cy.get("[data-cy=image]").should("be.visible");
-    //     cy.get("[data-cy=main-basket-1]").should("be.visible");
-    //   });
-    // });
+    it("is expected to display drink items", () => {
+      cy.get("[data-cy=drinks-tab]").should("contain", "Drinks");
+    });
+    it("is expected to display the contenet of the drink items", () => {
+      cy.get("[data-cy=sides-tab]").click();
+      cy.get("[data-cy=sides-item-1]").within(() => {
+        cy.get("[data-cy=name]").should("contain", "Mouse Wine");
+        cy.get("[data-cy=description]").should("contain", "Squeek!");
+        cy.get("[data-cy=price]").should("contain", "35 kr");
+        cy.get("[data-cy=image]").should("be.visible");
+        cy.get("[data-cy=main-basket-1]").should("be.visible");
+      });
+    });
   });
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,11 @@ const App = () => {
         <Route exact path="/" component={HomePage}></Route>
         <Route exact path="/menu" component={MenuPage}></Route>
         <Route exact path="/about" component={About}></Route>
+        <Route exact path="/starters" component={MenuPage}></Route>
+        <Route exact path="/main-menu" component={MenuPage}></Route>
+        <Route exact path="/dessert" component={MenuPage}></Route>
+        <Route exact path="/sides" component={MenuPage}></Route>
+        <Route exact path="/drinks" component={MenuPage}></Route>
       </Switch>
       <Footer />
     </BrowserRouter>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,11 +14,6 @@ const App = () => {
         <Route exact path="/" component={HomePage}></Route>
         <Route exact path="/menu" component={MenuPage}></Route>
         <Route exact path="/about" component={About}></Route>
-        <Route exact path="/starters" component={MenuPage}></Route>
-        <Route exact path="/main-menu" component={MenuPage}></Route>
-        <Route exact path="/dessert" component={MenuPage}></Route>
-        <Route exact path="/sides" component={MenuPage}></Route>
-        <Route exact path="/drinks" component={MenuPage}></Route>
       </Switch>
       <Footer />
     </BrowserRouter>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Switch, Route, BrowserRouter } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./components/HomePage";
-import Menu from "./components/Menu";
+import MenuPage from "./components/Menu";
 import About from "./components/About";
 
 const App = () => {
@@ -12,7 +12,7 @@ const App = () => {
       <Header />
       <Switch>
         <Route exact path="/" component={HomePage}></Route>
-        <Route exact path="/menu" component={Menu}></Route>
+        <Route exact path="/menu" component={MenuPage}></Route>
         <Route exact path="/about" component={About}></Route>
       </Switch>
       <Footer />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Icon, Menu } from "semantic-ui-react";
-import { NavLink, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 const Header = () => {
   const [activeItem, setActiveItem] = useState();
@@ -21,7 +21,7 @@ const Header = () => {
       <Menu.Item
         id="menu"
         name="menu"
-        as={NavLink}
+        as={Link}
         to={{ pathname: "/Menu" }}
         active={activeItem === "menu"}
         onClick={setActiveItem}
@@ -32,7 +32,7 @@ const Header = () => {
       <Menu.Item
         id="about"
         name="about"
-        as={NavLink}
+        as={Link}
         to={{ pathname: "/About" }}
         active={activeItem === "about"}
         onClick={setActiveItem}
@@ -46,7 +46,7 @@ const Header = () => {
       <Menu.Item
         id="cart"
         name="cart"
-        as={NavLink}
+        as={Link}
         to={{ pathname: "/Cart" }}
         data-cy="cart"
         active={activeItem === "cart"}

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -57,10 +57,12 @@ const MenuPage = () => {
             />
           </Menu>
         </Grid.Column>
-      </Grid>
+        <Grid.Column>
+        </Grid.Column>
       <Segment.Inline data-cy="menu-section" clearing>
         {menuList}
       </Segment.Inline>
+      </Grid>
     </div>
   );
 };

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -11,18 +11,13 @@ const MenuPage = () => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
     });
-  }, []);
-  useEffect(() => {
-    axios.get("https://slowfood.heroku.com/api/products").then((response) => {
-      setMenuItems(response.data.products);
-    });
   }, [activeCategory]);
 
-  const filteredCategory = menuItems.filter(
+  const itemsInCategories = menuItems.filter(
     (item) => item.category === activeCategory
   );
 
-  let menuList = filteredCategory.map((item) => {
+  let menuList = itemsInCategories.map((item) => {
     return <MenuItem key={item.id} item={item}></MenuItem>;
   });
 
@@ -38,7 +33,7 @@ const MenuPage = () => {
               onClick={() => setActiveCategory("starters")}
             />
             <Menu.Item
-              name="Main Menu"
+              name="Main Courses"
               data-cy="main-courses-tab"
               active={activeCategory === "main-menu"}
               onClick={() => setActiveCategory("main_courses")}

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -11,7 +11,7 @@ const MenuPage = () => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
     });
-  }, [activeCategory]);
+  }, []);
 
   const itemsInCategories = menuItems.filter(
     (item) => item.category === activeCategory

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -5,7 +5,6 @@ import axios from "axios";
 
 const MenuPage = () => {
   const [menuItems, setMenuItems] = useState([]);
-  const [activeItem, setActiveItem] = useState();
   const [activeCategory, setActiveCategory] = useState("starters");
 
   useEffect(() => {
@@ -35,7 +34,7 @@ const MenuPage = () => {
             <Menu.Item
               name="Starters"
               data-cy="starter-tab"
-              active={activeItem === "starters"}
+              active={activeCategory === "starters"}
               onClick={() => setActiveCategory("starters")}
             />
             <Menu.Item

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -18,7 +18,7 @@ const MenuPage = () => {
   );
 
   let menuList = itemsInCategories.map((item) => {
-    return <MenuItem key={item.id} item={item}></MenuItem>;
+    return <MenuItem key={item.id} item={item} />
   });
 
   return (

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -5,21 +5,32 @@ import axios from "axios";
 
 const MenuPage = () => {
   const [menuItems, setMenuItems] = useState([]);
-  const [activeItem, setActiveItem] = useState();
+  const [activeTab, setActiveTab] = useState();
   useEffect(() => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
+      setActiveTab()
     });
   }, []);
 
-  let menuList = menuItems.map((item) => {
+  const filteredCategory = menuItems.filter(
+    (item) => item.category === activeTab
+  );
+
+  let menuList = filteredCategory.map((item) => {
     return (
-      <List data-cy={`item-${item.id}`}>
-        <MenuItem item={item} />
+      <List key={item.id} data-cy={`item-${item.id}`}>
+        <List.Content
+          data-cy={`${activeTab.slice(0, -1)}-${filteredCategory.indexOf(
+            item
+          )}`}
+        >
+          <MenuItem item={item} />
+        </List.Content>
       </List>
     );
   });
-
+const tab = {tab: ""}
   return (
     <div>
       <Grid>
@@ -28,40 +39,40 @@ const MenuPage = () => {
             <Menu.Item
               name="Starters"
               data-cy="starter-tab"
-              active={activeItem === "starters"}
-              onClick={setActiveItem}
+              active={activeTab === "starters"}
+              onClick={setActiveTab}
             />
             <Menu.Item
               name="Main Menu"
               data-cy="main-menu-tab"
-              active={activeItem === "main-menu"}
-              onClick={setActiveItem}
+              active={activeTab === "main-menu"}
+              onClick={setActiveTab}
             />
             <Menu.Item
               name="Desserts"
               data-cy="dessert-tab"
-              active={activeItem === "desserts"}
-              onClick={setActiveItem}
+              active={activeTab === "desserts"}
+              onClick={setActiveTab}
             />
             <Menu.Item
               name="Sides"
               data-cy="sides-tab"
-              active={activeItem === "sides"}
-              onClick={setActiveItem}
+              active={activeTab === "sides"}
+              onClick={setActiveTab}
             />
             <Menu.Item
               name="Drinks"
               data-cy="drinks-tab"
-              active={activeItem === "drinks"}
-              onClick={setActiveItem}
+              active={activeTab === "drinks"}
+              onClick={setActiveTab}
             />
           </Menu>
         </Grid.Column>
-        <Grid.Column>
-        </Grid.Column>
-      <Segment.Inline data-cy="menu-section" clearing>
-        {menuList}
-      </Segment.Inline>
+        <Grid.Column></Grid.Column>
+        <Segment.Inline data-cy="menu-section" clearing>
+          {menuList}
+          {filteredCategory}
+        </Segment.Inline>
       </Grid>
     </div>
   );

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,87 +1,81 @@
 import React, { useState, useEffect } from "react";
-import { Segment, List, Grid, Menu } from "semantic-ui-react";
+import { Segment, Grid, Menu, Container, GridColumn } from "semantic-ui-react";
 import MenuItem from "./MenuItem";
 import axios from "axios";
+import { Link } from "react-router-dom";
 
 const MenuPage = () => {
   const [menuItems, setMenuItems] = useState([]);
-  const [activeTab, setActiveTab] = useState("starters");
+  const [activeItem, setActiveItem] = useState();
   useEffect(() => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
-      setActiveTab();
+      
     });
   }, []);
 
-  const filteredCategory = menuItems.filter(item => item.category === "main menu");
-
-  // let menuList = filteredCategory.map((item) => {
-  //   return (
-  //     <List key={item.id} data-cy={`item-${item.id}`}>
-  //       <List.Content
-  //         data-cy={`${activeTab.slice(0, -1)}-${filteredCategory.indexOf(
-  //           item.id
-  //         )}`}
-  //       >
-  //         <MenuItem item={item} />
-  //       </List.Content>
-  //     </List>
-  //   );
-  // });
+  const filteredCategory = menuItems.filter(
+    (item) => item.category === "starters"
+  );
 
   let menuList = filteredCategory.map((item) => {
-    return (
-      <List data-cy={`item-${item.id}`}>
-        <MenuItem item={item} />
-      </List>
-    );
+    return <MenuItem item={item} data-cy={`item-${item.id}`}></MenuItem>;
   });
 
-  // const tab = { tab: "" };
   return (
-    <div>
+    <Container>
       <Grid>
         <Grid.Column width={4}>
           <Menu fluid vertical tabular>
             <Menu.Item
+              id="tab"
               name="Starters"
               data-cy="starter-tab"
-              active={activeTab === "starters"}
-              onClick={setActiveTab}
+              active={activeItem === "starters"}
+              onClick={setActiveItem}
+              as={Link}
+              to={{ pathname: "/starters" }}
             />
             <Menu.Item
+              id="tab"
               name="Main Menu"
               data-cy="main-menu-tab"
-              active={activeTab === "main-menu"}
-              onClick={setActiveTab}
+              active={activeItem === "main-menu"}
+              onClick={() => setActiveItem({ tab: "main-menu" })}
+              as={Link}
+              to={{ pathname: "/main-menu" }}
             />
             <Menu.Item
               name="Desserts"
               data-cy="dessert-tab"
-              active={activeTab === "desserts"}
-              onClick={setActiveTab}
+              active={activeItem === "desserts"}
+              onClick={setActiveItem}
+              as={Link}
+              to={{ pathname: "/dessert" }}
             />
             <Menu.Item
               name="Sides"
               data-cy="sides-tab"
-              active={activeTab === "sides"}
-              onClick={setActiveTab}
+              active={activeItem === "sides"}
+              onClick={setActiveItem}
+              as={Link}
+              to={{ pathname: "/sides" }}
             />
             <Menu.Item
               name="Drinks"
               data-cy="drinks-tab"
-              active={activeTab === "drinks"}
-              onClick={setActiveTab}
+              active={activeItem === "drinks"}
+              onClick={setActiveItem}
+              as={Link}
+              to={{ pathname: "/drinks" }}
             />
           </Menu>
         </Grid.Column>
-        <Grid.Column></Grid.Column>
-        <Segment.Inline data-cy="menu-section" clearing>
-          {menuList}
-          {/* {filteredCategory} */}
-        </Segment.Inline>
+        <Grid.Column width={12}>
+          <Segment.Inline data-cy="menu-section">{menuList}</Segment.Inline>
+        </Grid.Column>
       </Grid>
-    </div>
+    </Container>
   );
 };
 

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,25 +1,33 @@
 import React, { useState, useEffect } from "react";
-import { Segment, Grid, Menu, Container, GridColumn } from "semantic-ui-react";
+import { Segment, Grid, Menu, Container } from "semantic-ui-react";
 import MenuItem from "./MenuItem";
 import axios from "axios";
-import { Link } from "react-router-dom";
 
 const MenuPage = () => {
   const [menuItems, setMenuItems] = useState([]);
-  const [activeItem, setActiveItem] = useState();
+  const [activeCategory, setActiveCategory] = useState("starters");
   useEffect(() => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
-      
     });
   }, []);
+  useEffect(() => {
+    axios.get("https://slowfood.heroku.com/api/products").then((response) => {
+      setMenuItems(response.data.products);
+    });
+  }, [activeCategory]);
 
-  const filteredCategory = menuItems.filter(
-    (item) => item.category === "starters"
-  );
+  const filteredCategory = menuItems.filter((item) => item.category === activeCategory);
+  
 
   let menuList = filteredCategory.map((item) => {
-    return <MenuItem item={item} data-cy={`item-${item.id}`}></MenuItem>;
+    return (
+      <MenuItem
+        key={item.id}
+        item={item}
+        
+      ></MenuItem>
+    );
   });
 
   return (
@@ -28,51 +36,40 @@ const MenuPage = () => {
         <Grid.Column width={4}>
           <Menu fluid vertical tabular>
             <Menu.Item
-              id="tab"
               name="Starters"
               data-cy="starter-tab"
-              active={activeItem === "starters"}
-              onClick={setActiveItem}
-              as={Link}
-              to={{ pathname: "/starters" }}
+              active={activeCategory === "starters"}
+              onClick={() => setActiveCategory()}
             />
             <Menu.Item
-              id="tab"
               name="Main Menu"
               data-cy="main-menu-tab"
-              active={activeItem === "main-menu"}
-              onClick={() => setActiveItem({ tab: "main-menu" })}
-              as={Link}
-              to={{ pathname: "/main-menu" }}
+              active={activeCategory == "main-menu"}
+              onClick={() => setActiveCategory()}
             />
             <Menu.Item
               name="Desserts"
               data-cy="dessert-tab"
-              active={activeItem === "desserts"}
-              onClick={setActiveItem}
-              as={Link}
-              to={{ pathname: "/dessert" }}
+              // active={activeCategory === "desserts"}
+              onClick={() => setActiveCategory()}
             />
             <Menu.Item
               name="Sides"
               data-cy="sides-tab"
-              active={activeItem === "sides"}
-              onClick={setActiveItem}
-              as={Link}
-              to={{ pathname: "/sides" }}
+              active={activeCategory === "sides"}
+              onClick={() => setActiveCategory()}
             />
             <Menu.Item
               name="Drinks"
               data-cy="drinks-tab"
-              active={activeItem === "drinks"}
-              onClick={setActiveItem}
-              as={Link}
-              to={{ pathname: "/drinks" }}
+              active={activeCategory === "drinks"}
+              onClick={() => setActiveCategory()}
             />
           </Menu>
         </Grid.Column>
         <Grid.Column width={12}>
-          <Segment.Inline data-cy="menu-section">{menuList}</Segment.Inline>
+          <h1>{activeCategory}</h1>
+          <Segment data-cy="menu-section">{menuList}</Segment>
         </Grid.Column>
       </Grid>
     </Container>

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -5,7 +5,9 @@ import axios from "axios";
 
 const MenuPage = () => {
   const [menuItems, setMenuItems] = useState([]);
+  const [activeItem, setActiveItem] = useState();
   const [activeCategory, setActiveCategory] = useState("starters");
+
   useEffect(() => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
@@ -17,17 +19,12 @@ const MenuPage = () => {
     });
   }, [activeCategory]);
 
-  const filteredCategory = menuItems.filter((item) => item.category === activeCategory);
-  
+  const filteredCategory = menuItems.filter(
+    (item) => item.category === activeCategory
+  );
 
   let menuList = filteredCategory.map((item) => {
-    return (
-      <MenuItem
-        key={item.id}
-        item={item}
-        
-      ></MenuItem>
-    );
+    return <MenuItem key={item.id} item={item}></MenuItem>;
   });
 
   return (
@@ -38,32 +35,32 @@ const MenuPage = () => {
             <Menu.Item
               name="Starters"
               data-cy="starter-tab"
-              active={activeCategory === "starters"}
-              onClick={() => setActiveCategory()}
+              active={activeItem === "starters"}
+              onClick={() => setActiveCategory("starters")}
             />
             <Menu.Item
               name="Main Menu"
-              data-cy="main-menu-tab"
-              active={activeCategory == "main-menu"}
-              onClick={() => setActiveCategory()}
+              data-cy="main-courses-tab"
+              active={activeCategory === "main-menu"}
+              onClick={() => setActiveCategory("main_courses")}
             />
             <Menu.Item
               name="Desserts"
-              data-cy="dessert-tab"
-              // active={activeCategory === "desserts"}
-              onClick={() => setActiveCategory()}
+              data-cy="desserts-tab"
+              active={activeCategory === "desserts"}
+              onClick={() => setActiveCategory("desserts")}
             />
             <Menu.Item
               name="Sides"
               data-cy="sides-tab"
               active={activeCategory === "sides"}
-              onClick={() => setActiveCategory()}
+              onClick={() => setActiveCategory("sides")}
             />
             <Menu.Item
               name="Drinks"
               data-cy="drinks-tab"
               active={activeCategory === "drinks"}
-              onClick={() => setActiveCategory()}
+              onClick={() => setActiveCategory("drinks")}
             />
           </Menu>
         </Grid.Column>

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from "react";
-import { Segment, List } from "semantic-ui-react";
+import { Segment, List, Grid, Menu } from "semantic-ui-react";
 import MenuItem from "./MenuItem";
 import axios from "axios";
 
-const Menu = () => {
+const MenuPage = () => {
   const [menuItems, setMenuItems] = useState([]);
+  const [activeItem, setActiveItem] = useState();
   useEffect(() => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
@@ -20,10 +21,48 @@ const Menu = () => {
   });
 
   return (
-    <Segment.Inline data-cy="menu-section" clearing>
-      {menuList}
-    </Segment.Inline>
+    <div>
+      <Grid>
+        <Grid.Column width={4}>
+          <Menu fluid vertical tabular>
+            <Menu.Item
+              name="Starters"
+              data-cy="starter-tab"
+              active={activeItem === "starters"}
+              onClick={setActiveItem}
+            />
+            <Menu.Item
+              name="Main Menu"
+              data-cy="main-menu-tab"
+              active={activeItem === "main-menu"}
+              onClick={setActiveItem}
+            />
+            <Menu.Item
+              name="Desserts"
+              data-cy="dessert-tab"
+              active={activeItem === "desserts"}
+              onClick={setActiveItem}
+            />
+            <Menu.Item
+              name="Sides"
+              data-cy="sides-tab"
+              active={activeItem === "sides"}
+              onClick={setActiveItem}
+            />
+            <Menu.Item
+              name="Drinks"
+              data-cy="drinks-tab"
+              active={activeItem === "drinks"}
+              onClick={setActiveItem}
+            />
+          </Menu>
+        </Grid.Column>
+      </Grid>
+      <Segment.Inline data-cy="menu-section" clearing>
+        {menuList}
+      </Segment.Inline>
+    </div>
   );
 };
 
-export default Menu;
+export default MenuPage;

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -5,32 +5,39 @@ import axios from "axios";
 
 const MenuPage = () => {
   const [menuItems, setMenuItems] = useState([]);
-  const [activeTab, setActiveTab] = useState();
+  const [activeTab, setActiveTab] = useState("starters");
   useEffect(() => {
     axios.get("https://slowfood.heroku.com/api/products").then((response) => {
       setMenuItems(response.data.products);
-      setActiveTab()
+      setActiveTab();
     });
   }, []);
 
-  const filteredCategory = menuItems.filter(
-    (item) => item.category === activeTab
-  );
+  const filteredCategory = menuItems.filter(item => item.category === "main menu");
+
+  // let menuList = filteredCategory.map((item) => {
+  //   return (
+  //     <List key={item.id} data-cy={`item-${item.id}`}>
+  //       <List.Content
+  //         data-cy={`${activeTab.slice(0, -1)}-${filteredCategory.indexOf(
+  //           item.id
+  //         )}`}
+  //       >
+  //         <MenuItem item={item} />
+  //       </List.Content>
+  //     </List>
+  //   );
+  // });
 
   let menuList = filteredCategory.map((item) => {
     return (
-      <List key={item.id} data-cy={`item-${item.id}`}>
-        <List.Content
-          data-cy={`${activeTab.slice(0, -1)}-${filteredCategory.indexOf(
-            item
-          )}`}
-        >
-          <MenuItem item={item} />
-        </List.Content>
+      <List data-cy={`item-${item.id}`}>
+        <MenuItem item={item} />
       </List>
     );
   });
-const tab = {tab: ""}
+
+  // const tab = { tab: "" };
   return (
     <div>
       <Grid>
@@ -71,7 +78,7 @@ const tab = {tab: ""}
         <Grid.Column></Grid.Column>
         <Segment.Inline data-cy="menu-section" clearing>
           {menuList}
-          {filteredCategory}
+          {/* {filteredCategory} */}
         </Segment.Inline>
       </Grid>
     </div>

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -4,7 +4,7 @@ import { List, Image } from "semantic-ui-react";
 const MenuItem = ({ item }) => {
   return (
     <List.Item data-cy={`item-${item.id}`}>
-      <Image data-cy="image" src={item.image} size="mini" />
+      <Image data-cy="image" src={item.image} size="mini" floated="right"/>
       <List.Content floated="left">
         <List.Header data-cy="name">{item.name}</List.Header>
         <List.Description data-cy="description">

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -4,7 +4,7 @@ import { List, Image } from "semantic-ui-react";
 const MenuItem = ({ item }) => {
   return (
     <List.Item data-cy={`item-${item.id}`}>
-      <Image data-cy="image" src={item.image} size="mini" floated="right"/>
+      <Image data-cy="image" src={item.image} size="mini" floated="right" />
       <List.Content floated="left">
         <List.Header data-cy="name">{item.name}</List.Header>
         <List.Description data-cy="description">

--- a/src/components/MenuItem.jsx
+++ b/src/components/MenuItem.jsx
@@ -3,7 +3,7 @@ import { List, Image } from "semantic-ui-react";
 
 const MenuItem = ({ item }) => {
   return (
-    <List.Item>
+    <List.Item data-cy={`item-${item.id}`}>
       <Image data-cy="image" src={item.image} size="mini" />
       <List.Content floated="left">
         <List.Header data-cy="name">{item.name}</List.Header>
@@ -16,7 +16,7 @@ const MenuItem = ({ item }) => {
         floated="right"
         name="cart"
         link
-        data-cy="add-to-basket"
+        data-cy={`add-to-basket-${item.id}`}
       ></List.Icon>
     </List.Item>
   );


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/179716948
### User story 
```
As a visitor 
In order to choose product more easily 
I would like to see the products sorted in categories
```
### Changes Proposed
- Meny tabs created to sort the different categories: 
- Starters 
- Main Courses 
- Desserts
- Sides
- Bread

- A filter function that helps to sort the categories to the right tabs

- ### What we learned working on this feature
- How to properly make use of map and filter functions, and useState, useEffect hooks
- How naming is extremely important
### Packages / Gems added
- Adds updated cypress version
### Screenshots (Videos
![Skärmavbild 2021-09-30 kl  18 00 10](https://user-images.githubusercontent.com/29585462/135491058-66947e6f-8d8a-433e-8383-5fdfa2040153.png)
)